### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build_latest.yml
+++ b/.github/workflows/build_latest.yml
@@ -1,6 +1,9 @@
 on:
   push:
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,5 +1,8 @@
 name: Run pytest unit tests
 
+permissions:
+  contents: read
+
 on: [push, pull_request]
 
 jobs:


### PR DESCRIPTION
Potential fix for [https://github.com/MHH-Humangenetik/clincnv2vcf/security/code-scanning/2](https://github.com/MHH-Humangenetik/clincnv2vcf/security/code-scanning/2)

In general, the problem is fixed by adding an explicit `permissions` block to the workflow (at the top level or per job) that limits the `GITHUB_TOKEN` to only the scopes required. For a simple test workflow that only checks out code and uploads artifacts, `contents: read` is sufficient.

The single best way to fix this without changing existing functionality is to add a root‑level `permissions` block immediately after the `name` (or `on`) declaration in `.github/workflows/test.yml`, setting `contents: read`. Root‑level `permissions` will apply to all jobs that don’t override it, so the existing `test` job will automatically use the restricted token. No steps in the job require write access, so this will not break anything.

Concretely, in `.github/workflows/test.yml`, between line 1 (`name: Run pytest unit tests`) and line 3 (`on: [push, pull_request]`), insert:

```yaml
permissions:
  contents: read
```

No additional imports, methods, or definitions are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
